### PR TITLE
Fix Bluebird Patch

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -4,11 +4,13 @@ var shimmer = require('shimmer');
 
 module.exports = function patchBluebird(ns) {
     if (typeof ns.bind !== 'function') {
-        throw new TypeError("must include namespace to patch bluebird against");
+        throw new TypeError('must include namespace to patch bluebird against');
     }
 
     var Promise = require('bluebird');
+    var async = require('bluebird/js/main/async');
     var proto = Promise && Promise.prototype;
+
     shimmer.wrap(proto, '_addCallbacks', function(_addCallbacks) {
         return function ns_addCallbacks(fulfill, reject, progress, promise, receiver) {
             if (typeof fulfill === 'function') fulfill = ns.bind(fulfill);
@@ -16,6 +18,18 @@ module.exports = function patchBluebird(ns) {
             if (typeof progress === 'function') progress = ns.bind(progress);
 
             return _addCallbacks.call(this, fulfill, reject, progress, promise, receiver);
+        };
+    });
+
+    shimmer.wrap(async, 'invokeLater', function(invokeLater) {
+        return function ns_invokeLater(fn, receiver, arg) {
+            return invokeLater.call(this, (typeof fn === 'function') ? ns.bind(fn) : fn, receiver, arg);
+        };
+    });
+
+    shimmer.wrap(async, 'invoke', function(invoke) {
+        return function ns_invoke(fn, receiver, arg) {
+            return invoke.call(this, (typeof fn === 'function') ? ns.bind(fn) : fn, receiver, arg);
         };
     });
 };


### PR DESCRIPTION
The previous patch was working _most_ of the time, but not always. Especially when returning a `thenable` - I was running into multiple cases where the CLS namespace was lost somewhere along the chain between "native" Bluebird promises and other, non-promise objects that implemented a `.then` method.

This changes the bluebird patch to wrap the `async` object that bluebird uses. This is based on the `process.domain` support in the bluebird code, and thus should be 100% correct.
