### PR TITLE
Bluebird 2.9.31 uses 6th argument, domain, to _addCallbacks

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -10,12 +10,12 @@ module.exports = function patchBluebird(ns) {
     var Promise = require('bluebird');
     var proto = Promise && Promise.prototype;
     shimmer.wrap(proto, '_addCallbacks', function(_addCallbacks) {
-        return function ns_addCallbacks(fulfill, reject, progress, promise, receiver) {
+        return function ns_addCallbacks(fulfill, reject, progress, promise, receiver, domain) {
             if (typeof fulfill === 'function') fulfill = ns.bind(fulfill);
             if (typeof reject === 'function') reject = ns.bind(reject);
             if (typeof progress === 'function') progress = ns.bind(progress);
 
-            return _addCallbacks.call(this, fulfill, reject, progress, promise, receiver);
+            return _addCallbacks.call(this, fulfill, reject, progress, promise, receiver, domain);
         };
     });
 };


### PR DESCRIPTION
Internally it does a strict `null` check, so relying on the default `undefined` will not work here.
