### PR TITLE
Removing CLS peer Dependency as it's not required

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "redis": "~0.9.0"
   },
   "peerDependencies": {
-    "continuation-local-storage": "~3",
     "bluebird": ">=1.0.3"
   }
 }


### PR DESCRIPTION
This causes issues with shrinkwrap when you're using this in a lib and then consuming the lib in another application. I'm pretty sure the peer dependency is unnecessary since it's not directly being required in the code.
