### PR TITLE
remove peer dependencies since they are not installed automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,12 @@
     "url": "https://github.com/TimBeyer/cls-bluebird/issues"
   },
   "dependencies": {
-    "shimmer": "~1"
+    "shimmer": "^1.0.0",
+    "bluebird": "^2.10.0"
   },
   "devDependencies": {
-    "tap": "~0.4.4",
-    "redis": "~0.9.0"
-  },
-  "peerDependencies": {
-    "continuation-local-storage": "~3",
-    "bluebird": ">=1.0.3"
+    "tap": "^0.4.4",
+    "redis": "^0.9.0",
+    "continuation-local-storage": "^3.0.0",
   }
 }


### PR DESCRIPTION
in npm@3 they are not installed automatically, see [docs](https://docs.npmjs.com/files/package.json#peerdependencies)

bumped versions as well, should be working tho...
