### PR TITLE
`Promise` argument to provide Bluebird version to be shimmed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 
 For documentation, check the above link.
 It works in the same way and uses the same tests.
+
+Only difference is the call signature. You can provide a specific Bluebird constructor to be shimmed, rather than the default.
+
+API: `clsBluebird( ns [, Promise] )`
+
+```js
+var cls = require('continuation-local-storage');
+var ns = cls.createNamespace('NODESPACE');
+
+var Promise = require('bluebird');
+var clsBluebird = require('clsBluebird');
+clsBluebird(ns, Promise);
+```


### PR DESCRIPTION
This PR changes the API from `patchBluebird( ns )` to `patchBluebird( ns, Promise )`.

The `Promise` argument is optional but allows the user to pass in a specific Bluebird constructor which they want shimmed for CLS.

Various use cases for this:
1. Wanting to use a particular version of bluebird
2. Wanting to use an independent instance of bluebird (i.e. not affecting the "global" Bluebird constructor that any other module gets with `require('bluebird')`
3. Will allow tests to be written which tests this module against different versions of Bluebird (e.g. v2 and v3)

Please let me know what you think...
