### PR TITLE
JSHint rules adjustment and npm script

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,44 +2,44 @@
     // Settings
     "passfail"      : false,  // Stop on first error.
     "maxerr"        : 100,    // Maximum errors before stopping.
- 
- 
+
+
     // Predefined globals whom JSHint will ignore.
     "browser"       : true,   // Standard browser globals e.g. `window`, `document`.
- 
+
     "node"          : true,
     "rhino"         : false,
     "couch"         : false,
-    "wsh"           : false,   // Windows Scripting Host.
- 
+    "wsh"           : false,  // Windows Scripting Host.
+
     "jquery"        : true,
     "prototypejs"   : false,
     "mootools"      : false,
     "dojo"          : false,
- 
-    "predef"        : [  // Extra globals.
-        "google",  // Google API variable.
-        "Android",  // PhoneGap variable.
-        "describe", // Testing
+
+    "predef"        : [       // Extra globals.
+        "google",             // Google API variable.
+        "Android",            // PhoneGap variable.
+        "describe",           // Testing
         "beforeEach",
         "afterEach",
         "it",
         "sinon",
         "should"
     ],
- 
- 
+
+
     // Development.
     "debug"         : false,  // Allow debugger statements e.g. browser breakpoints.
     "devel"         : true,   // Allow development statements e.g. `console.log();`.
- 
- 
+
+
     // EcmaScript 5.
-    //  "es5"           : true,   // Allow EcmaScript 5 syntax.
+    //  "es5"       : true,   // Allow EcmaScript 5 syntax.
     "strict"        : false,  // Require `use strict` pragma in every file.
     "globalstrict"  : false,  // Allow global "use strict" (also enables 'strict').
- 
- 
+
+
     // The Good Parts.
     "asi"           : false,  // Tolerate Automatic Semicolon Insertion (no semicolons).
     "laxbreak"      : true,   // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
@@ -61,11 +61,11 @@
     "shadow"        : false,  // Allows re-define variables later in code e.g. `var x=1; x=2;`.
     "supernew"      : false,  // Tolerate `new function () { ... };` and `new Object;`.
     "undef"         : true,   // Require all non-global variables be declared before they are used.
- 
- 
+
+
     // Personal styling prefrences.
-    "quotmark"      : "single", 
-    "indent"          : 4,   // Consistent indentation (requires jshint directive on files)
+    "quotmark"      : "single",
+    "indent"        : 4,      // Consistent indentation (requires jshint directive on files)
     "newcap"        : true,   // Require capitalization of all constructor functions e.g. `new F()`.
     "noempty"       : true,   // Prohibit use of empty blocks.
     "nonew"         : true,   // Prohibit use of constructors for side-effects.
@@ -74,5 +74,5 @@
     "plusplus"      : false,  // Prohibit use of `++` & `--`.
     "sub"           : false,  // Tolerate all forms of subscript notation besides dot notation e.g. `dict['key']` instead of `dict.key`.
     "trailing"      : true,   // Prohibit trailing whitespaces.
-    "white"         : false    // Check against strict whitespace and indentation rules.
+    "white"         : false   // Check against strict whitespace and indentation rules.
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,27 +5,19 @@
 
 
     // Predefined globals whom JSHint will ignore.
-    "browser"       : true,   // Standard browser globals e.g. `window`, `document`.
+    "browser"       : false,  // Standard browser globals e.g. `window`, `document`.
 
     "node"          : true,
     "rhino"         : false,
     "couch"         : false,
     "wsh"           : false,  // Windows Scripting Host.
 
-    "jquery"        : true,
+    "jquery"        : false,
     "prototypejs"   : false,
     "mootools"      : false,
     "dojo"          : false,
 
     "predef"        : [       // Extra globals.
-        "google",             // Google API variable.
-        "Android",            // PhoneGap variable.
-        "describe",           // Testing
-        "beforeEach",
-        "afterEach",
-        "it",
-        "sinon",
-        "should"
     ],
 
 
@@ -35,7 +27,7 @@
 
 
     // EcmaScript 5.
-    //  "es5"       : true,   // Allow EcmaScript 5 syntax.
+    "es5"           : false,  // Allow EcmaScript 5 syntax.
     "strict"        : false,  // Require `use strict` pragma in every file.
     "globalstrict"  : false,  // Allow global "use strict" (also enables 'strict').
 
@@ -45,14 +37,14 @@
     "laxbreak"      : true,   // Tolerate unsafe line breaks e.g. `return [\n] x` without semicolons.
     "bitwise"       : true,   // Prohibit bitwise operators (&, |, ^, etc.).
     "boss"          : false,  // Tolerate assignments inside if, for & while. Usually conditions & loops are for comparison, not assignments.
-    "curly"         : true,   // Require {} for every new block or scope.
+    "curly"         : false,  // Require {} for every new block or scope.
     "eqeqeq"        : true,   // Require triple equals i.e. `===`.
     "eqnull"        : false,  // Tolerate use of `== null`.
     "evil"          : false,  // Tolerate use of `eval`.
     "expr"          : false,  // Tolerate `ExpressionStatement` as Programs.
     "forin"         : false,  // Tolerate `for in` loops without `hasOwnPrototype`.
     "immed"         : true,   // Require immediate invocations to be wrapped in parens e.g. `( function(){}() );`
-    "latedef"       : true,   // Prohibit variable use before definition.
+    "latedef"       : "nofunc",  // Prohibit variable use before definition.
     "loopfunc"      : false,  // Allow functions to be defined within loops.
     "noarg"         : true,   // Prohibit use of `arguments.caller` and `arguments.callee`.
     "regexp"        : true,   // Prohibit `.` and `[^...]` in regular expressions.
@@ -61,6 +53,7 @@
     "shadow"        : false,  // Allows re-define variables later in code e.g. `var x=1; x=2;`.
     "supernew"      : false,  // Tolerate `new function () { ... };` and `new Object;`.
     "undef"         : true,   // Require all non-global variables be declared before they are used.
+    "unused"        : "strict",  // Require all defined variables and function parameters to be used after definition.
 
 
     // Personal styling prefrences.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Make bluebird work with the continuation-local-storage module.",
   "main": "shim.js",
   "scripts": {
-    "test": "tap test/*.tap.js"
+    "test": "npm run jshint && npm run test-main",
+    "test-main": "tap test/*.tap.js",
+    "jshint": "jshint shim.js test"
   },
   "repository": {
     "type": "git",
@@ -38,6 +40,7 @@
     "tap": "~0.4.4",
     "redis": "~0.9.0",
     "continuation-local-storage": "^3.1.7",
-    "bluebird": "^2.10.2"
+    "bluebird": "^2.10.2",
+    "jshint": "^2.9.2"
   }
 }

--- a/test/basic.tap.js
+++ b/test/basic.tap.js
@@ -1,5 +1,7 @@
 'use strict';
 
+// jshint quotmark:false
+
 var test = require('tap').test;
 
 test("promises + CLS without shim = failure", function (t) {


### PR DESCRIPTION
This PR:
- Modifies JSHint rules to match the code style used in the repo
- Adds an npm script for running JSHint (with `jshint` dev dependency)
- Runs JSHint on `npm test`

(this is basically a bit of tidy up in preparation for other changes)
