### PR TITLE
Improved validation that `ns` argument is a namespace

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* Improved validation that `ns` argument is a namespace
 * Add npm keywords
 
 ## 1.1.2

--- a/shim.js
+++ b/shim.js
@@ -9,9 +9,7 @@ try {
 } catch (err) {}
 
 module.exports = function patchBluebird(ns, Promise) {
-    if (typeof ns.bind !== 'function') {
-        throw new TypeError('must include namespace to patch bluebird against');
-    }
+    if (!ns || typeof ns.bind !== 'function' || typeof ns.run !== 'function') throw new TypeError('must include namespace to patch bluebird against');
 
     if (!Promise) {
         Promise = Bluebird;


### PR DESCRIPTION
This PR improves validation that the argument `ns` is a CLS namespace.

At present it's just checked that `ns` has a `bind` property which is a function. This test would be met by any function e.g. `function() {}`.

This PR also checks for a `run` property which is a function.
