### PR TITLE
fix: make coroutine.addYieldHandler work and wrap tapCatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea/

--- a/lib/index.js
+++ b/lib/index.js
@@ -180,7 +180,12 @@ module.exports = function patchBluebird(ns, Promise) {
 	 * NB `options.yieldHandler` will run in whatever CLS context is active at time of `yield`
 	 */
 
+  /**
+	 * Don't forget coroutine.addYieldHandler
+   */
+  var addYieldHandler = Promise.coroutine.addYieldHandler;
 	shimCoroutine('coroutine', Promise, ns, v3); // shims `Promise.coroutine()`
+  Promise.coroutine.addYieldHandler = addYieldHandler;
 
 	/*
 	 * Utility
@@ -197,6 +202,9 @@ module.exports = function patchBluebird(ns, Promise) {
 	 */
 
 	shimProto('tap', [0]);
+	if (v3) {
+		shimProto('tapCatch', [-1]);
+	}
 	shimCall(Promise, ns); // shims `.call()`
 
 	/*

--- a/test/methods/generators/coroutine.test.js
+++ b/test/methods/generators/coroutine.test.js
@@ -12,7 +12,7 @@ var runTests = require('../../support');
 
 runTests('Promise.coroutine()', function(u, Promise) {
 	if (u.nodeVersion.slice(0, 2) !== '0.') {
-		require('./coroutine.inc')(u, Promise.coroutine);
+		require('./coroutine.inc')(u, Promise.coroutine, 'coroutine');
 	} else {
 		it.skip('not supported by node version ' + u.nodeVersion);
 	}

--- a/test/methods/generators/spawn.test.js
+++ b/test/methods/generators/spawn.test.js
@@ -16,7 +16,7 @@
 			return function(handler) {
 				return Promise.spawn(fn.bind(null, handler));
 			};
-		});
+		}, 'spawn');
  	} else {
  		it.skip('not supported by node version ' + u.nodeVersion);
  	}


### PR DESCRIPTION
After shimCoroutine for Promise.coroutine, the origin method `Promise.coroutine.addYieldHandler` will missing.So, should add origin `Promise.coroutine.addYieldHandler` back to wrapped `Promise.coroutine`. And wrap bluebird v3 method `tapCatch`.